### PR TITLE
Add support for PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "magento2-module",
   "authors": [],
   "require": {
-    "php": "~7.1.0|~7.2.0|~7.3.0|~7.4.0",
+    "php": "~7.1|~8.1",
     "magento/module-review": ">=100.2.0"
   },
   "autoload": {


### PR DESCRIPTION
Since the latest Magento 2.4.4 version enforces the PHP version 8.1, we need to raise the compatibility and remove potential deprecations.